### PR TITLE
Fix registration password strength error

### DIFF
--- a/backend/controllers/authController.js
+++ b/backend/controllers/authController.js
@@ -36,10 +36,10 @@ const registerUser = async (req, res) => {
       return res.status(400).json({ message: 'Username already taken' });
     }
 
-    // Enforce password strength
-    const passwordStrong = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s]).{8,}$/;
-    if (!passwordStrong.test(password)) {
-      return res.status(400).json({ message: 'Password not strong enough' });
+    // Relaxed password policy: at least 6 chars and one number
+    const relaxedPasswordPolicy = /^(?=.*\d).{6,}$/;
+    if (!relaxedPasswordPolicy.test(password)) {
+      return res.status(400).json({ message: 'Password must be at least 6 characters and include a number' });
     }
 
     // Require email verified (registration flow should verify before saving)
@@ -280,10 +280,10 @@ const resetPassword = async (req, res) => {
     const user = await User.findOne({ email });
     if (!user) return res.status(404).json({ message: 'User not found' });
 
-    // Validate password strength
-    const passwordStrong = /^(?=.*[a-z])(?=.*[A-Z])(?=.*\d)(?=.*[^\w\s]).{8,}$/;
-    if (!passwordStrong.test(newPassword)) {
-      return res.status(400).json({ message: 'Password not strong enough' });
+    // Relaxed password policy aligned with registration
+    const relaxedPasswordPolicy = /^(?=.*\d).{6,}$/;
+    if (!relaxedPasswordPolicy.test(newPassword)) {
+      return res.status(400).json({ message: 'Password must be at least 6 characters and include a number' });
     }
 
     user.password = newPassword;

--- a/frontend/src/pages/RegisterPage.js
+++ b/frontend/src/pages/RegisterPage.js
@@ -372,7 +372,7 @@ const RegisterPage = () => {
                 required
                 placeholder="Create a password"
               />
-              <small>Min 8 chars, uppercase, lowercase, number, special</small>
+              <small>Min 6 chars and include a number</small>
             </div>
 
             <div className="register-field">


### PR DESCRIPTION
Relaxed password validation policy to fix "Password is not strong enough" error during registration.

The previous password policy was too strict, preventing users from registering with common passwords. This change updates the backend validation to require a minimum of 6 characters and at least one number, and updates the frontend hint accordingly, while still ensuring passwords are securely hashed with bcrypt.

---
<a href="https://cursor.com/background-agent?bcId=bc-ce626c08-dde6-4393-8a97-cece8bcea430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-cursor-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-cursor-light.svg"><img alt="Open in Cursor" src="https://cursor.com/open-in-cursor.svg"></picture></a>&nbsp;<a href="https://cursor.com/agents?id=bc-ce626c08-dde6-4393-8a97-cece8bcea430"><picture><source media="(prefers-color-scheme: dark)" srcset="https://cursor.com/open-in-web-dark.svg"><source media="(prefers-color-scheme: light)" srcset="https://cursor.com/open-in-web-light.svg"><img alt="Open in Web" src="https://cursor.com/open-in-web.svg"></picture></a>

